### PR TITLE
allow variable domain in apache config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 docker-moodle
 =============
 
-A Dockerfile that installs the latest Moodle, Apache, PHP, and SSH. This uses the official MySQL images from Docker Hub.
+A Dockerfile that installs the latest Moodle, Apache and PHP. This uses the official MySQL images from Docker Hub.
 
 ## Installation
 
@@ -15,10 +15,8 @@ Create ```.env``` to specify local details, e.g.,
 ```
 MYSQL_ROOT_PASSWORD=MyMy5QLPas$word
 MOODLE_PASSWORD=MyM00Dl3Pas$word
-SSH_PASSWORD=MyS54Pas$word
 VIRTUAL_HOST=my-moodle-host.my-moodle-domain
 CERT_EMAIL=email.to.use.f@r.letsencrypt
-CERT_DOMAIN=my-moodle-host.my-moodle-domain
 ```
 
 and create a directory ```/data/moodle-mysql``` to hold the MySQL DB persistently.
@@ -34,16 +32,36 @@ docker-compose build
 To spawn a new instance of Moodle:
 
 ```
+docker-compose build
 docker-compose up
 ```
 
 You can visit the following URL in a browser to get started:
 
 ```
-http://my-moodle-host.my-moodle-domain/moodle
+http://my-moodle-host.my-moodle-domain/
 ```
 
 Thanks to [sergiogomez](https://github.com/sergiogomez), [eugeneware](https://github.com/eugeneware) and [ricardoamaro](https://github.com/ricardoamaro) for their Dockerfiles.
+
+## SSL certificates
+
+By default a self-signed certificate is created. It is enough for local instances.
+
+Setting up a public instance do the following:
+
+```
+docker-compose exec moodle bash
+
+rm /etc/apache2/sites-enabled/default-ssl.conf
+rm -r /etc/letsencrypt/live
+/certbot-setup.sh
+exit
+
+docker-compose restart moodle
+```
+
+To renew the certificate later just run the /certbot-setup.sh within the container.
 
 ## Build images
 

--- a/moodle/000-default.conf
+++ b/moodle/000-default.conf
@@ -6,7 +6,7 @@
 	# match this virtual host. For the default virtual host (this file) this
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
-	ServerName learn.up2university.eu
+	ServerName ::VIRTUAL_HOST::
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot /var/www/html

--- a/moodle/Dockerfile
+++ b/moodle/Dockerfile
@@ -51,10 +51,8 @@ ADD ./config-dist.php /var/www/html/config-dist.php
 
 ENV MYSQL_PASSWORD ${MYSQL_ROOT_PASSWORD}
 ENV MOODLE_PASSWORD ${MOODLE_PASSWORD}
-ENV CERT_EMAIL ${CERT_EMAIL}
-ENV CERT_DOMAIN ${CERT_DOMAIN}
 
-RUN echo "certbot --non-interactive --test-cert --agree-tos --email $CERT_DOMAIN --apache --domains $CERT_DOMAIN" > /certbot-setup.sh
+RUN echo "certbot --non-interactive --agree-tos --email \$CERT_EMAIL --apache --domains \$VIRTUAL_HOST" > /certbot-setup.sh
 RUN chmod 755 /certbot-setup.sh 
 
 RUN curl -L https://github.com/kennibc/moodle-theme_fordson/archive/master.zip -o /fordson.zip
@@ -65,5 +63,5 @@ RUN curl -L https://moodle.org/plugins/download.php/13966/auth_saml2_moodle32_20
 RUN cp /auth_saml2.zip /var/www/html/auth/
 RUN cd /var/www/html/auth; unzip auth_saml2.zip
 
-EXPOSE 22 80 443
+EXPOSE 80 443
 CMD ["/bin/bash", "/start.sh"]

--- a/moodle/default-ssl.conf
+++ b/moodle/default-ssl.conf
@@ -1,7 +1,7 @@
 <IfModule mod_ssl.c>
 	<VirtualHost _default_:443>
 		ServerAdmin webmaster@localhost
-		ServerName learn.up2university.eu
+		ServerName ::VIRTUAL_HOST::
 
 		DocumentRoot /var/www/html
 
@@ -30,8 +30,8 @@
 		#   /usr/share/doc/apache2/README.Debian.gz for more info.
 		#   If both key and certificate are stored in the same file, only the
 		#   SSLCertificateFile directive is needed.
-		SSLCertificateFile	/etc/letsencrypt/live/learn.up2university.eu/cert.pem
-		SSLCertificateKeyFile /etc/letsencrypt/live/learn.up2university.eu/privkey.pem
+		SSLCertificateFile	/etc/letsencrypt/live/::VIRTUAL_HOST::/cert.pem
+		SSLCertificateKeyFile /etc/letsencrypt/live/::VIRTUAL_HOST::/privkey.pem
 
 		#   Server Certificate Chain:
 		#   Point SSLCertificateChainFile at a file containing the
@@ -137,7 +137,7 @@
 		# MSIE 7 and newer should be able to use keepalive
 		BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 
-SSLCertificateChainFile /etc/letsencrypt/live/learn.up2university.eu/chain.pem
+SSLCertificateChainFile /etc/letsencrypt/live/::VIRTUAL_HOST::/chain.pem
 	</VirtualHost>
 </IfModule>
 


### PR DESCRIPTION
So far, the Apache configuration has not allowed using a different domain than learn.up2university.eu. I change it to let it be the VIRTUAL_HOST variable, as set in .env file. 

By the way:
* I remove the CERT_DOMAIN variable as it looks to be always the same as VIRTUAL_HOST.
* certbot-setup.sh is fixed to use variable values on runtime, not on build time.
* I add self-signed cert generation to enable local testing and to let us run certbot on a fresh instance where /etc/letsencrypt is empty
