### PR TITLE
refactor mysql image

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,6 +1,7 @@
 FROM mysql/mysql-server:5.5
 
-RUN yum -y install gettext
+RUN yum -y install gettext \
+    && yum clean all
 
 COPY ./my.cnf /etc/my.cnf
 COPY ./start_mysql.sh /docker-entrypoint-initdb.d/start_mysql.sh


### PR DESCRIPTION
This simple change reduces the size of our MySQL image from 338 MB to 73 MB.