### PR TITLE
download an explicit version of Moodle

### DIFF
--- a/moodle/Dockerfile
+++ b/moodle/Dockerfile
@@ -64,8 +64,8 @@ RUN ln -s /etc/apache2/mods-available/rewrite.load /etc/apache2/mods-enabled/rew
     && ln -s /etc/apache2/sites-available/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf
 
 RUN cd /var/www \
-    && wget https://download.moodle.org/download.php/direct/stable33/moodle-latest-33.tgz -O moodle-latest.tgz \
-    && tar zxvf moodle-latest.tgz \
+    && curl 'https://git.moodle.org/gw?p=moodle.git;a=snapshot;h=2faddcdef50d655c3c6c06a6ae03425c1178be42;sf=tgz' -o moodle-latest.tgz \
+    && tar zxf moodle-latest.tgz --transform='s/moodle-[0-9a-f]*/moodle/g' \
     && rm moodle-latest.tgz \
     && mv /var/www/moodle /var/www/html \
     && chown -R www-data:www-data /var/www/html/

--- a/moodle/Dockerfile
+++ b/moodle/Dockerfile
@@ -65,9 +65,9 @@ RUN ln -s /etc/apache2/mods-available/rewrite.load /etc/apache2/mods-enabled/rew
 
 RUN cd /var/www \
     && curl 'https://git.moodle.org/gw?p=moodle.git;a=snapshot;h=2faddcdef50d655c3c6c06a6ae03425c1178be42;sf=tgz' -o moodle-latest.tgz \
-    && tar zxf moodle-latest.tgz --transform='s/moodle-[0-9a-f]*/moodle/g' \
+    && tar zxf moodle-latest.tgz \
     && rm moodle-latest.tgz \
-    && mv /var/www/moodle /var/www/html \
+    && mv /var/www/moodle* /var/www/html \
     && chown -R www-data:www-data /var/www/html/
 
 COPY ./config-dist.php /var/www/html/config-dist.php


### PR DESCRIPTION
The change as suggested by @athird.

@athird, I've dopped the "tar --transform" command as it changes too much (names of files inside too, not only the archive root directory). See the second commit.

I've tested that currenlty it gives exactly the same files as we get by moodle-latest.